### PR TITLE
29 - allow link attributes in text

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -30,6 +30,26 @@ function buildHeroBlock(main) {
   }
 }
 
+/** allow for link attributes to be added into link text
+ * ex: Link Text{target=blank,rel=noopener}
+ * @param main
+ */
+export function buildLinks(main) {
+  main.querySelectorAll('a').forEach((a) => {
+    const match = a.textContent.match(/(.*){([^}]*)}/);
+    if (match) {
+      // eslint-disable-next-line no-unused-vars
+      const [_, linkText, attrs] = match;
+      a.textContent = linkText;
+      a.title = linkText;
+      attrs.split(',').forEach((attr) => {
+        const [key, value] = attr.split('=');
+        a.setAttribute(key.trim(), value.trim());
+      });
+    }
+  });
+}
+
 /**
  * load fonts.css and set a session storage flag
  */
@@ -67,6 +87,7 @@ export function decorateMain(main) {
   buildAutoBlocks(main);
   decorateSections(main);
   decorateBlocks(main);
+  buildLinks(main);
 }
 
 /**


### PR DESCRIPTION

## Ticket/Issue number(s)
Fix #29 

## Test URLs
- Before: https://main--888de--aemsites.hlx.page/drafts/chelms/quelle-der-geldmittel
- After: https://29-linkauthoring--888de--aemsites.hlx.page/drafts/chelms/quelle-der-geldmittel

## Testing instructions
To author, put your link attributes without quotes, comma separated in curly braces.
example:
Hi I'm a link!{rel=noopener,target=_blank}