### PR TITLE
h1 for default and strong

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -141,13 +141,17 @@ h1 {
   margin-top: 0;
   word-wrap: break-word;
   scroll-margin: calc(var(--nav-height) + 1em);
+  display: block;
+  text-align: center;
 }
 
-h1 strong, strong h1 {
+h1 > strong, strong > h1 {
+  display: block;
   font-size: var(--heading-font-size-xxxl);
   font-family: var(--ultra-font-family);
   line-height: 1.5;
   font-weight: 900;
+  text-align: left;
 }
 
 h2 {


### PR DESCRIPTION
bug fix for 2 H1 styles.


## Test URLs
H1 should be centered less than 1200px wide
- Before: https://main--888de--aemsites.hlx.page/888club-tnc
- After: https://h1-fix--888de--aemsites.hlx.page/888club-tnc

H1 BOLD should be left aligned less than 1200px wide
- Before: https://main--888de--aemsites.hlx.page/faq-slots-de
- After: https://h1-fix--888de--aemsites.hlx.page/faq-slots-de


