### PR TITLE
json ld added to accordions

### DIFF
--- a/blocks/accordion/accordion.js
+++ b/blocks/accordion/accordion.js
@@ -15,7 +15,7 @@ function addFaqJson(block) {
         name: qaItem.querySelector('summary').textContent.trim(),
         acceptedAnswer: {
           '@type': 'Answer',
-          text: qaItem.querySelector('.accordion-item-body').innerHTML,
+          text: qaItem.querySelector('.accordion-item-body').textContent.trim(),
         },
       };
       return info;

--- a/blocks/accordion/accordion.js
+++ b/blocks/accordion/accordion.js
@@ -3,6 +3,26 @@
  * Recreate an accordion
  * https://www.hlx.live/developer/block-collection/accordion
  */
+import { addLdJsonScript } from '../../scripts/scripts.js';
+
+function addFaqJson(block) {
+  const data = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: [...block.querySelectorAll('details')].map((qaItem) => {
+      const info = {
+        '@type': 'Question',
+        name: qaItem.querySelector('summary').textContent.trim(),
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: qaItem.querySelector('.accordion-item-body').innerHTML,
+        },
+      };
+      return info;
+    }),
+  };
+  addLdJsonScript(document.querySelector('head'), data);
+}
 
 function hasWrapper(el) {
   return !!el.firstElementChild && window.getComputedStyle(el.firstElementChild).display === 'block';
@@ -30,4 +50,8 @@ export default function decorate(block) {
     details.append(summary, body);
     row.replaceWith(details);
   });
+
+  if (block.classList.contains('qa')) {
+    addFaqJson(block);
+  }
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -29,6 +29,18 @@ export function wrapSpanLink(element = document) {
 }
 
 /**
+ * Writes a script element with the LD JSON struct to the page
+ * @param {HTMLElement} parent
+ * @param {Object} json
+ */
+export function addLdJsonScript(parent, json) {
+  const script = document.createElement('script');
+  script.type = 'application/ld+json';
+  script.innerHTML = JSON.stringify(json);
+  parent.append(script);
+}
+
+/**
  * Decorates paragraphs containing a single link as buttons.
  * @param {Element} element container element
  */


### PR DESCRIPTION
First pass at adding ld+json script in header, per issue 38.
## Ticket/Issue number(s)
38 

## Test URLs
- Before: https://main--888de--aemsites.hlx.page/faq-slots-de
- After: https://json-accordion--888de--aemsites.hlx.page/faq-slots-de
- Before: https://main--888de--aemsites.hlx.page/888club/faq
- After: https://json-accordion--888de--aemsites.hlx.page/888club/faq

## Testing instructions
I don't know if this can be tested with the Google tool. until it is merged.
Put https://eds-dev-www.888.de/faq-slots-de in https://search.google.com/test/rich-results and it should report the ld+json.
A similar page with FAQ json is at https://www.888casino.com/live-casino/ .