### PR TITLE
only highlight first item

### DIFF
--- a/templates/inner-nav-fragment/inner-nav-fragment.js
+++ b/templates/inner-nav-fragment/inner-nav-fragment.js
@@ -37,8 +37,12 @@ export default async function decorate(doc) {
     const success = await getLeftNav(currentPath) || await getLeftNav(parentPath);
 
     if (success) {
+      let matchFirst = true;
       $aside.querySelectorAll('a').forEach(($link) => {
-        if ($link.href.replace(/\/$/, '') === currentPath) $link.parentElement.classList.add('active');
+        if (matchFirst && $link.href.replace(/\/$/, '') === currentPath) {
+          $link.parentElement.classList.add('active');
+          matchFirst = false;
+        }
       });
     }
   })();


### PR DESCRIPTION
Fixes issue when left nav has multiple links with the same path. Following the current site only the first one is highlighted. 



## Test URLs
- Before: https://main--888de--aemsites.hlx.live/banking/einzahlung/wie-einzahlen
- After: https://left-nav-highlifght-fix--888de--aemsites.hlx.live/banking/einzahlung/wie-einzahlen

## Testing instructions
Verify only the first link is active. 