### PR TITLE
163 - removing title attribute from href

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -135,7 +135,6 @@ export function buildLinks(main) {
       // eslint-disable-next-line no-unused-vars
       const [_, linkText, attrs] = match;
       a.textContent = linkText;
-      a.title = linkText;
       // match all attributes between curly braces
       attrs.split('|').forEach((attr) => {
         const [key, ...values] = attr.split('=');


### PR DESCRIPTION

Fix #163
## Test URLs
- Before: https://main--888de--aemsites.hlx.page/
- After: https://163-link-title-attribute--888de--aemsites.hlx.page/

## Testing instructions
Ensure title attribute isn't showing links
