### PR TITLE
change html lang to de

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -357,7 +357,7 @@ export async function breadcrumbs(doc) {
  * @param {Element} doc The container element
  */
 async function loadEager(doc) {
-  document.documentElement.lang = 'en';
+  document.documentElement.lang = 'de';
   const templateName = getMetadata('template');
   decorateTemplateAndTheme(templateName);
 


### PR DESCRIPTION
Change lang from en to de.
## Ticket/Issue number(s)
Fix #161

## Test URLs
- Before: https://main--888de--aemsites.hlx.page/
- After: https://161-language--888de--aemsites.hlx.page/

## Testing instructions
You should see Google ask to translate from German (if your browser is in english and you haven't blocked this). 
When merged, the cookie banner should appear in German as well.
