### PR TITLE
placeholder above 888-main.js

### DIFF
--- a/head.html
+++ b/head.html
@@ -1,6 +1,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <script src="/scripts/aem.js" type="module"></script>
 <script src="/scripts/scripts.js" type="module"></script>
+<!-- Placeholder: sCut -->
 <script src="/scripts/888-main.js" type="module"></script>
 <script>
   dataLayer = window.dataLayer || [];


### PR DESCRIPTION
From Rafi:
The funnel data script is placed by default before the first script that comes from the CMS. it's injected first thing on the page head so that the sCut object is initialized as soon as possible so that any script that wants to use it will have it ready by then. (is aem.js using the sCut object in it ??)
you can change the location of this script by adding the following comment on the page head:
<!-- Placeholder: sCut -->
the script will be placed after this comment.


## Ticket/Issue number(s)
Fix #217 

## Test URLs
- Before: https://main--888de--aemsites.hlx.page/
- After: https://217-scut--888de--aemsites.hlx.page/

## Testing instructions
after doing this change 
[@Nave Naim](https://adobe-dx-support.slack.com/team/U06HD5KCRJL)
 it is important to test all the places that touch the sCut object, the logic that passes the funnel parameters from the current site to other sites.
so 
[@Charity Helms](https://adobe-dx-support.slack.com/team/U04KZ24LABG)
 - add the comment where you wish this script to be, test the score and then 
[@Nave Naim](https://adobe-dx-support.slack.com/team/U06HD5KCRJL)
 should retest this functionality of adding the parameters between sites.
